### PR TITLE
Fix new API error

### DIFF
--- a/plex_playlist_update.py
+++ b/plex_playlist_update.py
@@ -21,7 +21,7 @@ import xmltodict
 import ConfigParser
 from lxml.html import parse
 from plexapi.server import PlexServer
-from plexapi.utils import NA
+NA=""
 
 from urllib2 import Request, urlopen
 


### PR DESCRIPTION
To fix:
```
Traceback (most recent call last):
  File "./plex_playlist_update.py", line 24, in <module>
    from plexapi.utils import NA
ImportError: cannot import name NA
```